### PR TITLE
Modernize Node version matrix to [20, 22, 24]

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16, 18, 20]
+        node-version: [20, 22, 24]
 
     steps:
     - uses: actions/checkout@v4
@@ -38,10 +38,10 @@ jobs:
       run: npx eslint src
 
     - name: Generate Documentation
-      if: matrix.node-version == 18
+      if: matrix.node-version == 22
       run: npm run docs
     - name: Archive Documentation
-      if: matrix.node-version == 18
+      if: matrix.node-version == 22
       uses: actions/upload-artifact@v4
       with:
         name: documentation


### PR DESCRIPTION
## Summary
- Drop EOL Node versions: 16 (EOL Sep 2023) and 18 (EOL Apr 2025).
- Test against the currently-supported tier: 20 (maintenance), 22 (Active LTS), 24 (Active).
- Move the docs-publish step from Node 18 to Node 22 since 18 was dropped.

This is a prerequisite for the open major-version dep bumps (#145 eslint v10, #148 node-gyp v12, #150 ava v8), which all require Node >=20.x or higher.

## Test plan
- [x] `act push --matrix node-version:20 -j build` — green locally
- [x] `act push --matrix node-version:22 -j build` — lint + docs generate green
- [ ] GitHub Actions matrix (20/22/24) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)