### PR TITLE
Release prep 0.7.0: docs, changelog, metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to this project are documented in this file. The format is
+based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
+project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.7.0]
+
+Connector architecture: transport handling moved out of `DroneConnection` into
+pluggable connectors, adding Wifi support alongside Bluetooth LE (#21, #164).
+
+### Added
+- `BaseConnector`, `BLEConnector` and `WifiConnector`, all exported from the
+  package, plus `DroneCommand`.
+- Wifi support: mDNS auto-discovery (optional native `mdns`) or a direct
+  `connect(host, port)`.
+- `'error'` event on connectors/`DroneConnection`, forwarded from the transport.
+- Acknowledgement handling for both transports — outgoing commands resolve on
+  the drone's ACK, and incoming `DATA_WITH_ACK` frames are acked back.
+- A `node:test` test suite (`npm test`) run in CI on Node 20/22/24, and an
+  `engines` (`node >=20`) and `files` allow-list in `package.json`.
+
+### Changed
+- **Breaking:** `DroneConnection` now takes a connector instance, e.g.
+  `new DroneConnection(new BLEConnector())`. See "Migrating from 0.6.x" in the
+  README.
+- `mdns` is now an `optionalDependency`, so installs no longer fail when it
+  cannot be built; only no-argument Wifi discovery requires it.
+- Dependency cleanup: dropped the unused `ava` and the redundant `dgram`/`net`
+  shims, and moved `node-gyp` to `devDependencies`.
+
+### Fixed
+- `BLEConnector` crashed on connect (wrong `receiveUuids` import) and called the
+  non-existent `noble.warn`; errors in noble callbacks now emit `'error'`
+  instead of throwing uncatchably.
+- Wifi mDNS discovery passed the whole service object instead of host/port.
+- `WifiConnector.connected` always reported `false` after connecting.
+- `DroneConnection` forwarded the wrong disconnect event, never re-emitted
+  sensor events, and called the non-existent `DroneCommand.copy()`.
+
+[0.7.0]: https://github.com/Mechazawa/minidrone-js/releases/tag/v0.7.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2018 Mechazawa <mega@ioexception.at>
+Copyright 2018-2026 Mechazawa <mega@ioexception.at>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -75,6 +75,84 @@ void async function() {
 }();
 ```
 
+## Connectors
+
+A `DroneConnection` wraps a *connector* that handles the transport. Two are provided:
+
+| Connector | Transport | `connect()` |
+| --- | --- | --- |
+| `BLEConnector` | Bluetooth LE (via `@abandonware/noble`) | `connect()` — scans for and connects to a nearby drone |
+| `WifiConnector` | Wifi (UDP/TCP) | `connect()` — auto-discovers over mDNS; or `connect(host, port)` to connect directly |
+
+```js
+const { DroneConnection, WifiConnector } = require('minidrone-js');
+
+const drone = new DroneConnection(new WifiConnector());
+// drone.connector.connect();          // mDNS auto-discovery
+// drone.connector.connect('192.168.99.3', 44444); // or connect directly
+```
+
+mDNS auto-discovery relies on the optional native [`mdns`] dependency. It is an
+`optionalDependency`, so installs never fail when it can't be built (e.g. on Node
+versions where it has no prebuilt binary). Without it, BLE and the direct
+`connect(host, port)` path still work — only no-argument Wifi discovery needs it
+(it rejects with a clear error otherwise). On Linux `mdns` needs
+`libavahi-compat-libdnssd-dev`.
+
+[`mdns`]: https://www.npmjs.com/package/mdns
+
+You can also use a connector directly without `DroneConnection`:
+
+```js
+const { WifiConnector, CommandParser } = require('minidrone-js');
+
+const parser = new CommandParser();
+const drone = new WifiConnector();
+
+drone.on('connected', () => drone.sendCommand(parser.getCommand('minidrone', 'Piloting', 'TakeOff')));
+drone.connect();
+```
+
+### Events
+
+`DroneConnection` (and the connectors) are `EventEmitter`s:
+
+| Event | Fired when |
+| --- | --- |
+| `connected` | the drone is connected and ready for commands |
+| `disconnected` | the connection to the drone was lost |
+| `error` | the underlying transport raised an error |
+| `sensor:<token>` | a sensor reading arrived (e.g. `sensor:minidrone-UsbAccessoryState-GunState`) |
+| `sensor:*` | any sensor reading arrived |
+
+```js
+drone.on('sensor:minidrone-UsbAccessoryState-GunState', (sensor) => {
+  if (sensor.state.value === sensor.state.enum.READY) {
+    console.log('The gun is ready to fire!');
+  }
+});
+```
+
+> **Error handling.** Like any Node `EventEmitter`, an `'error'` event with no
+> listener is thrown. Attach an `'error'` handler if you want to recover from
+> transport errors instead of crashing.
+
+## Migrating from 0.6.x
+
+`DroneConnection` no longer talks to the radio itself — it now takes a connector:
+
+```js
+// 0.6.x
+const drone = new DroneConnection();
+
+// 0.7.0+
+const drone = new DroneConnection(new BLEConnector()); // or new WifiConnector()
+```
+
+`connect()` lives on the connector, and `BLEConnector`/`WifiConnector` are
+exported from the package. Everything else (`runCommand`, `getSensor`,
+`sensor:*` events, `CommandParser`) is unchanged.
+
 ## Troubleshooting
 
 #### MacOS won't connect to the drone
@@ -103,7 +181,7 @@ blueutil on
 
 MIT License
 
-Copyright 2018 Mechazawa <mega@ioexception.at>
+Copyright 2018-2026 Mechazawa <mega@ioexception.at>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -1,11 +1,20 @@
 {
   "name": "minidrone-js",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Parrot Minidrone library",
   "main": "index.js",
   "repository": "https://github.com/Mechazawa/minidrone-js",
   "author": "Bas 'Mechazawa' <mega@ioexception.at>",
   "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
+  "files": [
+    "src",
+    "index.js",
+    "README.md",
+    "LICENSE"
+  ],
   "dependencies": {
     "@abandonware/noble": "^1.9.2-23",
     "arsdk-xml": "1.0.0",


### PR DESCRIPTION
Prep for the 0.7.0 release (the connector API from #21 + the test/dep work in #164).

- **Version** 0.6.1 → **0.7.0** (the `DroneConnection(connector)` change is breaking; 0.x breaking → minor bump).
- **README**: connector model (BLE vs Wifi) + `connect()` contracts, events table, error-handling note, and a **Migrating from 0.6.x** section.
- **CHANGELOG.md** added for 0.7.0.
- **`files` allow-list** → npm ships only `src/`, `index.js`, `README.md`, `LICENSE` (tarball drops from a bloated set incl. a 116 kB example lockfile to **18 files / 20.6 kB**).
- **`engines`: node >=20** (matches CI matrix).
- **Copyright → 2018-2026** (LICENSE + README).

No runtime code changes. Lint clean, jsdoc clean, 39 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)