### PR TITLE
Auto-generate TypeScript declarations from JSDoc

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -46,6 +46,9 @@ jobs:
     - name: Test
       run: npm test
 
+    - name: Build type declarations
+      run: npm run build:types
+
     - name: Generate Documentation
       if: matrix.node-version == 22
       run: npm run docs

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /dist/
 /build/
 /docs/
+/types/
 !/src/
 /local/
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ and sending commands based on the [xml specification].
 npm install minidrone-js --save
 ```
 
+## TypeScript
+
+The package ships TypeScript declarations (`.d.ts`), generated from the JSDoc, so
+editors and TypeScript projects get autocompletion and type-checking out of the
+box — no separate `@types` package required.
+
 ## Example
 
 This example will make the drone take-off, do a flip and then land again.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,10 +20,12 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@stylistic/eslint-plugin": "^5.10.0",
+        "@types/node": "^25.9.1",
         "eslint": "^10.4.1",
         "globals": "^17.6.0",
         "jsdoc": "^4.0.2",
-        "node-gyp": "^12.0.0"
+        "node-gyp": "^12.0.0",
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=20"
@@ -621,6 +623,16 @@
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
     },
     "node_modules/@types/triple-beam": {
       "version": "1.3.5",
@@ -3200,6 +3212,20 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/uc.micro": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
@@ -3222,6 +3248,13 @@
       "engines": {
         "node": ">=18.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unique-filename": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "Parrot Minidrone library",
   "main": "index.js",
+  "types": "types/index.d.ts",
   "repository": "https://github.com/Mechazawa/minidrone-js",
   "author": "Bas 'Mechazawa' <mega@ioexception.at>",
   "license": "MIT",
@@ -11,6 +12,7 @@
   },
   "files": [
     "src",
+    "types",
     "index.js",
     "README.md",
     "LICENSE"
@@ -27,10 +29,12 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@stylistic/eslint-plugin": "^5.10.0",
+    "@types/node": "^25.9.1",
     "eslint": "^10.4.1",
     "globals": "^17.6.0",
     "jsdoc": "^4.0.2",
-    "node-gyp": "^12.0.0"
+    "node-gyp": "^12.0.0",
+    "typescript": "^6.0.3"
   },
   "optionalDependencies": {
     "mdns": "^2.4.0"
@@ -38,6 +42,8 @@
   "scripts": {
     "test": "node --test",
     "docs": "npx jsdoc --configure .jsdoc.json --verbose; mkdir -p docs; rm -r docs; mv build/docs/minidrone-js/* docs; rm -r build/docs",
-    "lint": "npx eslint src --fix --cache"
+    "lint": "npx eslint src --fix --cache",
+    "build:types": "tsc -p tsconfig.json",
+    "prepack": "tsc -p tsconfig.json"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "types",
+    "rootDir": ".",
+    "module": "node16",
+    "moduleResolution": "node16",
+    "target": "es2020",
+    "skipLibCheck": true,
+    "noEmitOnError": false,
+    "types": ["node"]
+  },
+  "include": ["index.js", "src/**/*.js"],
+  "exclude": ["node_modules", "test", "examples", "types", "build", "docs"]
+}


### PR DESCRIPTION
The codebase has thorough JSDoc, so we can emit `.d.ts` with `tsc` (`--allowJs --declaration --emitDeclarationOnly`) instead of hand-writing/maintaining types.

- **`tsconfig.json`** — emits declarations only (no type-checking) from `index.js` + `src/` into `types/`.
- **`package.json`** — adds the `types` entry (`types/index.d.ts`), a `build:types` script, and a **`prepack`** hook so every publish ships fresh declarations that match the code. `types/` is in the `files` allow-list and **gitignored** (generated, not committed).
- **CI** — builds the declarations on all matrix versions, so JSDoc that breaks type emit fails the build.
- **README** — brief TypeScript note.

Adds devDeps `typescript` + `@types/node`. The emitted types are accurate, e.g.:
```ts
declare class DroneConnection extends EventEmitter {
  constructor(connector: BaseConnector, warmup?: boolean);
  get parser(): CommandParser;
  runCommand(command: DroneCommand): Promise<any>;
}
```
Verified `npm pack` regenerates and ships all 15 declaration files; jsdoc + lint + 39 tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)