### PR TITLE
Publish to npm on version tags (Trusted Publishing)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,48 @@
+name: Publish
+
+# Publishes to npm when a version tag (v*) is pushed. The tag must match the
+# version in package.json. Authentication uses npm Trusted Publishing (OIDC) —
+# no NPM_TOKEN secret is needed; configure this repo + workflow as a trusted
+# publisher for the package on npmjs.com. Provenance is generated automatically.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  id-token: write # OIDC token for npm Trusted Publishing + provenance
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22
+        registry-url: 'https://registry.npmjs.org'
+    - name: Update npm (Trusted Publishing needs npm >= 11.5.1)
+      run: npm install -g npm@latest
+    - name: Install OS Packages
+      run: sudo apt update && sudo apt install -y libavahi-compat-libdnssd-dev
+    - name: Install Dependencies
+      run: npm ci
+    - name: Verify tag matches package.json version
+      run: |
+        PKG_VERSION="$(node -p "require('./package.json').version")"
+        TAG_VERSION="${GITHUB_REF_NAME#v}"
+        echo "tag=$TAG_VERSION package.json=$PKG_VERSION"
+        if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+          echo "::error::Tag $GITHUB_REF_NAME does not match package.json version $PKG_VERSION"
+          exit 1
+        fi
+    - name: Lint
+      run: npx eslint src
+    - name: Test
+      run: npm test
+    - name: Publish to npm
+      # OIDC trusted publishing — no token; prepack regenerates the .d.ts first.
+      run: npm publish --access public


### PR DESCRIPTION
Adds `.github/workflows/publish.yml` so pushing a `v*` tag publishes to npm automatically.

**Auth: npm Trusted Publishing (OIDC)** — no `NPM_TOKEN` secret. The workflow requests `id-token: write`; npm exchanges the GitHub OIDC token for a short-lived publish credential and attaches provenance automatically. Configure the package's trusted publisher on npmjs.com as `Mechazawa/minidrone-js` → workflow `publish.yml` (no environment). This satisfies the package's 2FA-for-publish requirement.

Flow on a `v*` tag push:
1. Verify the tag matches `package.json` version (fails the run otherwise).
2. `npm ci`, lint, test — so a broken tag won't publish.
3. `npm publish --access public` — `prepack` regenerates the `.d.ts` first.

npm is upgraded to latest in-job because Trusted Publishing needs npm ≥ 11.5.1 (newer than Node 22 bundles).

**Releasing is now: bump the version in package.json, commit, push `vX.Y.Z`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)