### PR TITLE
Load noble lazily and allow injecting it (fixes #82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project are documented in this file. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- TypeScript declarations (`.d.ts`) generated from the JSDoc, shipped in the
+  package (#167).
+- `BLEConnector` accepts a custom `noble` instance: `new BLEConnector(filter, noble)` (#82).
+- CI publishes to npm on `v*` tags via Trusted Publishing (#168).
+
+### Changed
+- `BLEConnector` loads `@abandonware/noble` lazily, so a missing/unsupported
+  native binding no longer breaks `require('minidrone-js')` for Wifi or
+  custom-connector users (#82).
+- Migrated ESLint to v10 (flat config) (#166).
+
 ## [0.7.0]
 
 Connector architecture: transport handling moved out of `DroneConnection` into

--- a/README.md
+++ b/README.md
@@ -119,6 +119,23 @@ drone.on('connected', () => drone.sendCommand(parser.getCommand('minidrone', 'Pi
 drone.connect();
 ```
 
+### Bluetooth on unsupported hardware, or a custom transport
+
+`BLEConnector` uses [`@abandonware/noble`], loaded lazily — a missing or
+unsupported native binding no longer breaks `require('minidrone-js')`; only
+constructing a default `BLEConnector` needs noble. If your Bluetooth hardware
+isn't supported, you can:
+
+- **Inject your own noble** (e.g. one configured with a custom hci-socket binding):
+  `new BLEConnector(droneFilter, myNoble)`.
+- **Use Wifi instead** — `WifiConnector` needs no Bluetooth at all.
+- **Bring your own transport** — extend `BaseConnector`, implement `connect()` and
+  `sendCommand(command)`, and emit `connected`, `incoming` (a parsed
+  `DroneCommand`) and `disconnected`. Pass it to `DroneConnection` like any other
+  connector.
+
+[`@abandonware/noble`]: https://www.npmjs.com/package/@abandonware/noble
+
 ### Events
 
 `DroneConnection` (and the connectors) are `EventEmitter`s:

--- a/src/connectors/BLEConnector.js
+++ b/src/connectors/BLEConnector.js
@@ -1,4 +1,3 @@
-const noble = require('@abandonware/noble');
 const BaseConnector = require('./BaseConnector');
 const Logger = require('winston');
 const { bufferType } = require('../BufferEnums');
@@ -21,10 +20,18 @@ const DRONE_PREFIXES = [
 ];
 
 class BLEConnector extends BaseConnector {
-  constructor(droneFilter = '') {
+  /**
+   * @param {string} [droneFilter=''] - Only connect to a drone with this advertised name
+   * @param {object} [noble] - A noble instance to use for BLE. Defaults to
+   *   `@abandonware/noble`, loaded lazily so the package still works (over Wifi or a
+   *   custom connector) when noble's native binding is unavailable. Pass your own
+   *   noble (e.g. configured with a custom hci-socket binding) for unsupported hardware.
+   */
+  constructor(droneFilter = '', noble = require('@abandonware/noble')) {
     super();
 
     this.droneFilter = droneFilter;
+    this.noble = noble;
 
     this._characteristicLookupCache = {};
     this.characteristics = [];
@@ -42,15 +49,15 @@ class BLEConnector extends BaseConnector {
       return;
     }
 
-    if (noble.state === 'unknown') {
+    if (this.noble.state === 'unknown') {
       Logger.debug('Noble state is unknown. Waiting for it to change to poweredOn');
-      noble.once('stateChange', () => this.connect());
-    } else if (noble.state === 'poweredOn') {
+      this.noble.once('stateChange', () => this.connect());
+    } else if (this.noble.state === 'poweredOn') {
       Logger.info('Searching for drones...');
 
-      noble.on('discover', peripheral => this._onPeripheralDiscovery(peripheral));
+      this.noble.on('discover', peripheral => this._onPeripheralDiscovery(peripheral));
 
-      noble.startScanning();
+      this.noble.startScanning();
     }
   }
 
@@ -69,7 +76,7 @@ class BLEConnector extends BaseConnector {
 
     Logger.info(`Peripheral found ${peripheral.advertisement.localName}`); // ex: Mambo_646859
 
-    noble.stopScanning();
+    this.noble.stopScanning();
 
     peripheral.connect((error) => {
       if (error) {
@@ -156,7 +163,7 @@ class BLEConnector extends BaseConnector {
        *
        * @event BaseConnector#disconnected
        */
-      noble.on('disconnect', () => this.disconnect());
+      this.noble.on('disconnect', () => this.disconnect());
 
       setTimeout(() => {
         /**

--- a/test/ble-connector.test.js
+++ b/test/ble-connector.test.js
@@ -1,10 +1,17 @@
 'use strict';
 
-// BLEConnector requires '@abandonware/noble', whose native binding may be absent
-// in this environment. Intercept the module loader and hand back a fake before
-// requiring BLEConnector so the test never touches real BLE hardware.
-const Module = require('module');
-const _load = Module._load;
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+const BLEConnector = require('../src/connectors/BLEConnector');
+const { bufferType } = require('../src/BufferEnums');
+const { sendUuids } = require('../src/CharacteristicEnums');
+
+// Silence the harmless "[winston] Attempt to write logs with no transports" noise.
+require('winston').clear();
+
+// A stand-in for @abandonware/noble so the tests never load the native binding
+// or touch real BLE hardware. Injected via the BLEConnector constructor.
 const fakeNoble = {
   on() {},
   once() {},
@@ -13,27 +20,14 @@ const fakeNoble = {
   startScanning() {},
   stopScanning() {},
 };
-Module._load = function (request, ...rest) {
-  return request === '@abandonware/noble' ? fakeNoble : _load.call(this, request, ...rest);
-};
-
-const BLEConnector = require('../src/connectors/BLEConnector');
-const { bufferType } = require('../src/BufferEnums');
-const { sendUuids } = require('../src/CharacteristicEnums');
-
-const { test } = require('node:test');
-const assert = require('node:assert');
-
-// Silence the harmless "[winston] Attempt to write logs with no transports" noise.
-require('winston').clear();
 
 /**
- * Build a fresh connector with a warmed-up parser and a stubbed write() that
- * records every frame instead of touching a noble characteristic.
+ * Build a fresh connector with an injected (fake) noble, a warmed-up parser, and a
+ * stubbed write() that records every frame instead of touching a noble characteristic.
  * @returns {{ connector: BLEConnector, sent: Array<{buf: Buffer, ch: string}> }}
  */
 function makeConnector() {
-  const connector = new BLEConnector();
+  const connector = new BLEConnector('', fakeNoble);
 
   connector.parser.warmup();
 
@@ -47,6 +41,20 @@ function makeConnector() {
 
   return { connector, sent };
 }
+
+test('the package and BLEConnector load without noble\'s native binding (issue #82)', () => {
+  // Requiring the package must not eagerly require @abandonware/noble - otherwise a
+  // missing/unsupported native binding crashes Wifi and custom-connector users too.
+  const index = require('../src');
+
+  assert.strictEqual(typeof index.BLEConnector, 'function', 'BLEConnector should load');
+
+  // And a custom noble can be injected (e.g. one configured for unsupported hardware).
+  const connector = new BLEConnector('drone-name', fakeNoble);
+
+  assert.strictEqual(connector.noble, fakeNoble, 'the injected noble instance should be used');
+  assert.strictEqual(connector.droneFilter, 'drone-name', 'the drone filter should be set');
+});
 
 test('sendCommand writes one frame for an ack command and registers a flat callback', async () => {
   const { connector, sent } = makeConnector();
@@ -196,8 +204,6 @@ test('_handleIncoming acks a DATA_WITH_ACK frame and still emits incoming', () =
 });
 
 test('the package index exports the public connector and command surface', () => {
-  // The noble mock is still active, so requiring the index (which pulls in
-  // BLEConnector) is safe.
   const index = require('../src');
 
   assert.strictEqual(typeof index.DroneCommand, 'function', 'DroneCommand should be exported');
@@ -206,12 +212,4 @@ test('the package index exports the public connector and command surface', () =>
   assert.strictEqual(typeof index.BLEConnector, 'function', 'BLEConnector should be exported');
   assert.strictEqual(typeof index.WifiConnector, 'function', 'WifiConnector should be exported');
   assert.strictEqual(typeof index.CommandParser, 'function', 'CommandParser should be exported');
-});
-
-// Restore the original module loader so the interception does not leak into
-// other test files sharing the process.
-test('restore the module loader', () => {
-  Module._load = _load;
-
-  assert.strictEqual(Module._load, _load, 'the original module loader should be restored');
 });


### PR DESCRIPTION
Fixes #82 — *"Unable to connect via Bluetooth … is there some way to bypass the built-in connection and connect manually?"*

`BLEConnector` did `require('@abandonware/noble')` at **module load**, so an unsupported/missing native binding crashed `require('minidrone-js')` for everyone — including Wifi-only and custom-transport users.

- **Lazy noble** — the require moved into the `BLEConnector` constructor's default param, so importing the package (and using `WifiConnector` or a custom connector) no longer needs noble. Verified `require('minidrone-js')` now succeeds without the native binding.
- **Injectable noble** — `new BLEConnector(droneFilter, noble)`, so users with unsupported hardware can pass a noble configured with their own hci-socket binding.
- **README** — new "Bluetooth on unsupported hardware, or a custom transport" section: inject your own noble, use Wifi, or extend `BaseConnector`.
- **Test** — now injects a fake noble (drops the module-loader hack) and asserts the package loads without the binding.
- **CHANGELOG** — `[Unreleased]` section (also captures the eslint 10 / TS types / publish-workflow work that landed after 0.7.0).

Backward compatible (`new BLEConnector()` still defaults to `@abandonware/noble`). Lint clean, 39 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)