### PR TITLE
Release 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented in this file. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.1]
 
 ### Added
 - TypeScript declarations (`.d.ts`) generated from the JSDoc, shipped in the
@@ -52,4 +52,5 @@ pluggable connectors, adding Wifi support alongside Bluetooth LE (#21, #164).
 - `DroneConnection` forwarded the wrong disconnect event, never re-emitted
   sensor events, and called the non-existent `DroneCommand.copy()`.
 
+[0.7.1]: https://github.com/Mechazawa/minidrone-js/releases/tag/v0.7.1
 [0.7.0]: https://github.com/Mechazawa/minidrone-js/releases/tag/v0.7.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "minidrone-js",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "minidrone-js",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "@abandonware/noble": "^1.9.2-23",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minidrone-js",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Parrot Minidrone library",
   "main": "index.js",
   "types": "types/index.d.ts",


### PR DESCRIPTION
Bumps version to **0.7.1** and rolls up everything merged since 0.7.0 (which was published before this work landed):

- TypeScript `.d.ts` declarations generated from JSDoc (#167)
- **#82 fix** — lazy + injectable noble (`require('minidrone-js')` works without the native binding)
- ESLint v10 flat config (#166)
- Tag-triggered npm publish via OIDC (#168)

CHANGELOG `[Unreleased]` promoted to `[0.7.1]`; lockfile synced.

On merge, pushing `v0.7.1` triggers the publish workflow → first real run of the automated OIDC pipeline, shipping the TypeScript types + #82 fix to npm consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)